### PR TITLE
I587 - use staged passwords

### DIFF
--- a/changes/002-machine-specific-passwords.sh
+++ b/changes/002-machine-specific-passwords.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+echo "Enabling the science team to read from /secret/database/science"
+vault policy-write dbread-science config/dbread-science.policy
+vault write auth/github/map/teams/science value=dbread-science

--- a/changes/003-remove-policy-dbread.sh
+++ b/changes/003-remove-policy-dbread.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ -f config/dbread.policy ]; then
+    echo "ERROR: First remove config/dbread.policy (see VIMC-587)"
+    exit 1
+fi
+
+echo "Removing science read permissions from /secret/database"
+vault delete auth/github/map/teams/science
+vault policy-delete dbread

--- a/changes/003-remove-policy-dbread.sh
+++ b/changes/003-remove-policy-dbread.sh
@@ -9,3 +9,10 @@ fi
 echo "Removing science read permissions from /secret/database"
 vault delete auth/github/map/teams/science
 vault policy-delete dbread
+
+USERS="api import orderly readonly schema_migrator"
+for U in $USERS; do
+    KEY="secret/database/users/$U"
+    echo "Removing password $KEY"
+    vault delete $KEY
+done

--- a/config/dbread-science.policy
+++ b/config/dbread-science.policy
@@ -1,0 +1,4 @@
+# Allow read only access to database passwords on science
+path "secret/database/science" {
+    policy = "read"
+}


### PR DESCRIPTION
This needs running in stages, potentially.  The first part sets up the policy to make passwords readable for science, the second revokes the previous policy.

It's possible depending on how we deploy this that we might do this in one step.

For now, passwords for all groups are the same (once this is all done we'll regenerate new passwords)