### PR TITLE
i1399: Update vault version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:0.7.3
+FROM vault:0.9.1
 RUN apk add --update openssl curl
 
 COPY vault.conf /vault/config/


### PR DESCRIPTION
Working with @weshinsley to try and narrow down a windows vault access failure and wanted to try upgrading the vault.  We're on a release from June and this is current.  No rush on merging this but it seems worthwhile to try and keep up to date