### PR TITLE
i1631 - use named volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:0.9.1
+FROM vault:0.9.6
 RUN apk add --update openssl curl
 
 COPY vault.conf /vault/config/

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ The tricky bit in this process is getting the ssl certificate private key into t
 You will need a copy of the vault's (encrypted) storage which can be retrieved by running, within a fresh checkout of this repository:
 
 ```
-ssh -t support.montagu sudo tar -zcvf ~/storage.tar.gz /montagu/vault/storage
+ssh -t support.montagu sudo tar -C /montagu/vault -zcvf ~/storage.tar.gz storage
 scp support.montagu:storage.tar.gz .
-sudo tar -zxvf storage.tar.gz -C /
+tar -zxvf storage.tar.gz
+./scripts/directory-to-volume.sh storage montagu_vault_data
 ssh support.montagu rm ~/storage.tar.gz
 rm storage.tar.gz
+rm -r storage
 ```
-
-(Before running those commands you probably want to ensure that `/montagu/vault/storage` is empty or does not exist)
 
 Then, in order to simulate access to the vault over https, add the following line to `/etc/hosts`:
 

--- a/run.sh
+++ b/run.sh
@@ -4,12 +4,25 @@ set -e
 HERE=$(dirname $0)
 
 MONTAGU_VAULT=montagu-vault
+MONTAGU_VAULT_DATA=montagu_vault_data
+MONTAGU_VAULT_LOGS=montagu_vault_logs
+
+if ! docker volume inspect "$MONTAGU_VAULT_DATA" > /dev/null 2>&1; then
+    echo "Error: docker volume $MONTAGU_VAULT_DATA does not exist"
+    exit 1
+fi
+
+if ! docker volume inspect "$MONTAGU_VAULT_LOGS" > /dev/null 2>&1; then
+    docker volume create "$MONTAGU_VAULT_LOGS"
+fi
+
 docker build -t $MONTAGU_VAULT $HERE
 
 docker run -d --rm \
        --cap-add=IPC_LOCK \
        --name montagu-vault \
-       -v /montagu/vault/storage:/vault/file \
+       -v $MONTAGU_VAULT_DATA:/vault/file \
+       -v $MONTAGU_VAULT_LOGS:/vault/logs \
        -p "8200:8200" \
        $MONTAGU_VAULT
 

--- a/scripts/directory-to-volume.sh
+++ b/scripts/directory-to-volume.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# copy the contents of a directory into a new docker volume
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage $0 <source> <destination>"
+    exit 1
+fi
+
+SRC="$1"
+DEST="$2"
+
+if [ ! -d $SRC ]; then
+    echo "Error: path $SRC must be a directory"
+    exit 1
+fi
+
+if docker volume inspect "$DEST" > /dev/null 2>&1; then
+    echo "Error: docker volume $DEST already exists"
+    exit 1
+fi
+
+SRC=$(realpath $SRC)
+
+echo -n "Creating docker volume "
+docker volume create "$DEST"
+
+echo "Copying files"
+docker run \
+       --rm \
+       -v "$SRC":/src \
+       -v "$DEST":/dest \
+       alpine:latest \
+       ash -c "cd /src; tar cf - . | (cd /dest && tar xf -)"
+
+echo "Done"


### PR DESCRIPTION
Process for deploying this change:

1. stop the vault
2. migrate the data to a new data volume by running, on support:

```
./scripts/directory-to-volume.sh /montagu/vault/storage montagu_vault_data
```

3. restart the vault as before
4. delete `/montagu/vault/storage`

This PR also adds a new volume for the vault logs.